### PR TITLE
Add SHA-256 checksums to every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
         run: |
           grep -m 2 -B 1000 '^## ' bin/release-notes.md | tail -n +3 | head -n -2 > final_notes.md
           cat bin/instructions.md >> final_notes.md
+          printf "\n\nSHA-256 checksums:\n\`\`\`\n" >> final_notes.md
+          find ./bin/ -name "bt-*" -type f -exec sha256sum {} \; | sed -E -n 's/([a-z0-9]+)( *)\.\/bin\/(.*)/\1\2\3/p' >> final_notes.md
+          printf "\`\`\`\n" >> final_notes.md
           cat final_notes.md
           
 


### PR DESCRIPTION
![example](https://github.com/aloneguid/bt/assets/37241775/64fd23d9-b4c5-417f-a2c6-9d4db87e17bf)

sha256sum line explanation:
- `find ./bin/ -name "bt-*" -type f`
  - Finding all files (usually `bt-v.zip` and `bt-v.msi`) like bt-*
- `-exec sha256sum {} \; | `
  - Calculating SHA-256 of each file above
- `sed -E -n 's/([a-z0-9]+)( *)\.\/bin\/(.*)/\1\2\3/p'`
  - obvi, sed
  - pattern
    - `([a-z0-9]+)` - capturing hash
    - `( *)` - capturing whitespaces
    - `\.\/bin\/` - deleting `bin` path from output
    - `(.*)` - capturing filename
    - `\1\2\3` - hash + whitespace + filename