### PR TITLE
Update tab instead of create; close with timeout

### DIFF
--- a/browser-extensions/chromium/background.js
+++ b/browser-extensions/chromium/background.js
@@ -8,23 +8,26 @@
 
 const BtProtoPrefix = "x-bt://";
 
-async function openInBT(url) {
+async function openInBT(tabId, url) {
     const destUrl = BtProtoPrefix + url;
-    await chrome.tabs.create({ url: destUrl });
+    await chrome.tabs.update(tabId, { url: destUrl });
 }
 
 chrome.action.onClicked.addListener((activeTab) => {
     const url = activeTab.url;
     // as we are sending the url to BT, we can close the current tab
-    chrome.tabs.remove(activeTab.id);
-
-    openInBT(url);
+    openInBT(activeTab.id, url).then(() => {
+        // using a timeout because I can't find a reliable way to wait for the custom protocol to be handled
+        setTimeout(() => {
+            chrome.tabs.remove(activeTab.id);
+        }, 250);
+    });
 });
 
 // context menu item click handler
 chrome.contextMenus.onClicked.addListener((info, tab) => {
     const url = info.linkUrl;
-    openInBT(url);
+    openInBT(tab.id, url);
 });
 
 // add context menu item for a hyperlink (contexts: link)


### PR DESCRIPTION
The change from `chrome.tabs.update` to `chrome.tabs.create` in 8519cde7700ed5d2acf74f560e7404712aefbd6c made it so using the context menu would leave an empty tab behind.

(Brave also started popping up "A website wants to open this application" confirmation messages every time, which was extremely annoying; I don't know if that was a result of the change, or of an unrelated browser update. I worked around it with registry changes, but the open tab still bothered me.)

When clicking the extension icon, I couldn't find a good way to wait for the custom protocol handler to run and then close the current tab, so I resorted to a `setTimeout`.