### PR TITLE
Fix links on docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@
 - Supports [URL processing](https://aloneguid.github.io/bt/url-proc.html), which allows for custom URL pre-processing with
   - [URL un-shortening](https://aloneguid.github.io/bt/url-proc.html#un-shortening).
   - [Office 365 URL unwrapping](https://aloneguid.github.io/bt/url-proc.html#office-365-link-unwrapping).
-  - [Find/replace](http://localhost:63342/wrs/preview/url-proc.html#substitutions) functionality, including regular expression support.
+  - [Find/replace](https://aloneguid.github.io/bt/url-proc.html#substitutions) functionality, including regular expression support.
 - [Custom scripting](https://aloneguid.github.io/bt/scripting.html) for URL processing and rule matching using [Lua](https://www.lua.org/) programming language.
 - [Pipeline debugger](https://aloneguid.github.io/bt/debugger.html) brings clarity to complicated rules and pipelines.
 - **[Extensions](https://aloneguid.github.io/bt/browser-extensions.html)** to integrate with Chrome, Edge, Firefox, or any Chromium-based or Firefox-based browser (Opera, Vivaldi, Brave, Waterfox, LibreWolf etc.).

--- a/wrs/topics/home.md
+++ b/wrs/topics/home.md
@@ -29,7 +29,7 @@ If yes, then you need %product%! It's a smart and powerful tool that acts as a b
 - Supports [URL processing](https://aloneguid.github.io/bt/url-proc.html), which allows for custom URL pre-processing with
   - [URL un-shortening](https://aloneguid.github.io/bt/url-proc.html#un-shortening).
   - [Office 365 URL unwrapping](https://aloneguid.github.io/bt/url-proc.html#office-365-link-unwrapping).
-  - [Find/replace](http://localhost:63342/wrs/preview/url-proc.html#substitutions) functionality, including regular expression support.
+  - [Find/replace](https://aloneguid.github.io/bt/url-proc.html#substitutions) functionality, including regular expression support.
 
 - **[Extensions](https://aloneguid.github.io/bt/browser-extensions.html)** to integrate with Chrome, Edge, Firefox, or any Chromium-based or Firefox-based browser (Opera, Vivaldi, Brave, Waterfox, LibreWolf etc.).
   [![Chrome Web Store Version](https://img.shields.io/chrome-web-store/v/oggcljknmiiomjekepdoindjcpnpglnd)](https://chrome.google.com/webstore/detail/browser-tamer/oggcljknmiiomjekepdoindjcpnpglnd)  [![Mozilla Add-on Version](https://img.shields.io/amo/v/browser-tamer)](https://addons.mozilla.org/eu/firefox/addon/browser-tamer/)


### PR DESCRIPTION
I notice that some links on docs are point to localhost. This commit fix those links.